### PR TITLE
Fixed typo, format fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ It shows you, how to setup the communication between PI/Pimatic and the controll
 
 
 
-The source code for the micro-controller is avaible [here](https://github.com/dfischbach/pimatic-athome-arduino).
+The source code for the micro-controller is available [here](https://github.com/dfischbach/pimatic-athome-arduino).
 
-##Installation
+## Installation
 To enable the AtHome plugin add this section to your config.json file.
 
 ```


### PR DESCRIPTION
Added space after ## marker to get sub-heading properly rendered at https://pimatic.org/plugins/pimatic-athome/
